### PR TITLE
Move app to correct platform category

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ It's free & open-source. Enjoy! 🚀
 | - | - | - | - |
 | 💰 | [Tim Time Tracker](https://tim.neat.software) | Native macOS time tracker with menu bar app, scripting, powerful charts and data organization. | 30% OFF with code **BF24NSCO** |
 | 🚀 | [DeskRest](https://www.deskrest.app/offers) | Smart break and posture reminder for macOS. Transform your workday. | 70% OFF with code **BLACKFRIDAY70** |
-| 💪 | [Calorimeter](https://calorimeter.app) | Native & lightweight iOS companion for tracking and managing your daily calorie burn. | PRO Lifetime - 50%  OFF, PRO Annual - 70% OFF with code **BF2024** |
 
 ### Writing & Notes
 | | Name | Description | Deal |
@@ -383,6 +382,7 @@ It's free & open-source. Enjoy! 🚀
 | 😌 | [Quiet - Meditation Timer](https://apps.apple.com/app/apple-store/id6480446368) | A minimalist meditation timer. No guide. No distraction. | Lifetime plan - 50% OFF |
 | 💪 | [BodyPeak](https://apps.apple.com/app/id6476585712) | Take your workouts to the next level with BodyPeak, your iOS coach for muscle building and workout tracking. Stay motivated, track progress, and crush your goals! | **33% OFF Annual Plan** |
 | 🚭 | [Smoke Count](https://apps.apple.com/us/app/smoke-count-cigarette/id6503163176) | Break free from cigarettes! Get daily reminders, track your progress, and stay motivated. Start your journey today! | **Lifetime 100% off** |
+| 💪 | [Calorimeter](https://calorimeter.app) | Native & lightweight iOS companion for tracking and managing your daily calorie burn. | PRO Lifetime - 50%  OFF, PRO Annual - 70% OFF with code **BF2024** |
 
 ### Hobby & Lifestyle
 | | Name | Description | Deal |


### PR DESCRIPTION
Accidentally added my iOS app under wrong platform(MacOS) in my last PR.