### PR TITLE
Add Shotomatic deal to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ It's free & open-source. Enjoy! 🚀
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
 | 🏏 | [Clobbr](https://clobbr.app) | The app & CLI tool to load test your API endpoints. | **50% off** in the AppStore (already applied) | 2025-12-31 |
+| 📸 | [Shotomatic](https://shotomatic.com) | Easily archive eBooks, dashboards, and long-page documents through automated screenshots. | **40% OFF** with discount code **BF2025** | 2025-12-01 |
 
 
 ### APIs, Tools & SaaS
@@ -161,7 +162,7 @@ It's free & open-source. Enjoy! 🚀
 
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
-| ⭐ | Be the first to add a deal in this category! | | | |
+| 📸 | [Shotomatic](https://shotomatic.com) | Easily archive eBooks, dashboards, and long-page documents through automated screenshots. | **40% OFF** with discount code **BF2025** | 2025-12-01 |
 
 
 ### Design Tools


### PR DESCRIPTION
Added Shotomatic to the deals section with details!

Shotomatic is a macOS app that automatically captures long pages, eBooks, and dashboards — perfect for creators who need clean screenshots for archiving or research.
It saves hours of manual work with a simple, automated workflow.