### PR TITLE
Adding Once - Shared Disposable Camera App

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ It's free & open-source. Enjoy! 🚀
 
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
-| ⭐ | Be the first to add a deal in this category! | | | |
+| 📸 | [Once](https://once.film) | Shared disposable camera app for events—capture memories together and unlock the full gallery when the event ends. | **50% OFF** when joining the early access waitlist | 2025-12-31 |
 
 
 ### Health & Fitness


### PR DESCRIPTION
**Once** is a shared disposable camera app for events, available on iOS.

How Once Works:
1. Create a film for your event and set the rules
2. Share a QR code or link so guests can join in seconds (No download needed for guests)
3. Everyone shoots in the moment with limited shots per person
4. Photos unlock together at the time you choose, ready to relive and save