### PR TITLE
Add viral.app analytics deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ It's free & open-source. Enjoy! 🚀
 | - | - | - | - | - |
 | ⭐ | [Subreddit Traffic Tracker](https://subreddittraffic.live/) | Reach maximum Reddit traffic by finding the best times to post. Track 400+ subreddits activity and optimize your posting schedule to increase your brand awareness and traffic. | 30% OFF on all plans with code **BLACKFRIDAY2025** | |
 | 📈 | [Reporting - Ad Network Reports](https://apps.apple.com/app/apple-store/id1559813249) | Track and monitor your daily, weekly, and monthly ad network revenue effortlessly in a single convenient location. | **50% OFF** lifetime plan. No code needed. | 2025-12-02 |
+| 📈 | [viral.app](https://viral.app) | UGC analytics platform to track TikTok, Instagram, and YouTube performance for brands and agencies. | **30% OFF** the first 3 months on monthly plans with code **viralblackfriday30**. | 2025-12-07 |
 
 ### Website Builders
 


### PR DESCRIPTION
## Summary
- add viral.app to the Marketing > Analytics section
- document the viralblackfriday30 code (30% off first 3 months on monthly plans)
- note the redemption deadline (December 7, 2025)

## Testing
- [x] previewed README locally to verify table formatting