### PR TITLE
Add Protego for Reddit - Safari Web Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ It's free & open-source. Enjoy! 🚀
 | ⚡ | [CalmTab](https://addons.mozilla.org/en-GB/firefox/addon/calmtab/) | Clean Firefox start page with clocks, notes, quotes, search and tab workspaces | 33 percent off first year with code blackfriday | 2025-11-29 |
 | ⏸️ | [DeskBreak](https://deskbreak.app) | Smart break reminders for remote workers and developers. Prevent burnout with customizable desk breaks, activity tracking, and health insights. | **50% OFF** with code **BLACKFRIDAY** | 2025-12-03 |
 | ⚡ | [Ultimate Web Scraper](https://ultimatewebscraper.com) | The best no-code web scraper chrome extension. Grab text, images, emails & links from any website with a single click. | **20% OFF** with code **BLACKFRIDAY20** | 2025-12-02 |
+| 🛡️ | [Protego for Reddit](https://apps.apple.com/us/app/protego-for-reddit/id6737959724?mt=12&at=1010loaC) | Safari Web Extension that filters unwanted content on Reddit. Block posts by keywords and domains, hide ads. Works across macOS, iOS, iPadOS, and visionOS. | **50% OFF** ($0.99, was $1.99) | 2025-12-06 |
 
 
 ### Productivity & AI


### PR DESCRIPTION
Hi! I'd like to add Protego for Reddit to the Browser Extensions section.

**What is Protego?**
Protego is a Safari Web Extension that filters unwanted content on Reddit. It helps users control what they see by blocking posts based on keywords and domains, hiding ads and promoted content, and cleaning up the Reddit interface.

**Black Friday Deal:**
- 🛡️ 50% OFF (/bin/zsh.99, was .99)
- Valid until: December 6, 2025
- Works across macOS, iOS, iPadOS, and visionOS
- App Store: https://apps.apple.com/us/app/protego-for-reddit/id6737959724?mt=12

**Why Browser Extensions section?**
Protego is a Safari Web Extension that enhances the Reddit browsing experience, making it a perfect fit for this category alongside other browser extensions.

Added to the Browser Extensions section. Thanks for reviewing!