### PR TITLE
Add VicSee to AI Tools > Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Free & open-source.
 
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
+| 🎬 | [VicSee](https://vicsee.com) | AI video & image studio with Sora 2, Veo 3.1, Kling 2.6, Hailuo 2.3, Nano Banana Pro and FLUX.2 — 7 model families in one place. | **20% OFF** forever with code **RBD20** | 2025-03-31 |
 | 🖼️ | [ThumblifyAI](https://thumblifyai.com) | Create scroll-stopping YouTube thumbnails in your own style or face with AI. | **30% OFF** with discount code **WELCOME30** | 2025-12-01 |
 | 👀 | [ChampSignal](https://champsignal.com) | ChampSignal tracks your competitors' websites, social mentions, ads, backlinks, and keywords, and sends you email alerts only when it matters. | **25% OFF** with code **BF2025** | 2025-12-01 |
 | 🤖 | [ShowUpInAI](https://showupinai.com) | Get Cited in ChatGPT and more! We push every new page to Bing, helping AI assistants cite your site. | **25% OFF** with code **BLACKFRIDAY25** | 2025-12-01 |


### PR DESCRIPTION
Adding VicSee to the AI Tools > Other section.

**VicSee** is an AI video & image studio featuring:
- Sora 2 & Sora 2 Pro (OpenAI)
- - Veo 3.1 (Google)
- - Kling 2.6, Hailuo 2.3
- - Nano Banana Pro (4K images)
- - FLUX.2 (multi-reference generation)
**Deal:** 20% OFF forever with code **RBD20**

Website: https://vicsee.com