### PR TITLE
Add VideoLens to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Free & open-source.
 
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
+| 🎬 | [VideoLens](https://videolens.cc/?utm_source=rarebigdeal) | Professional AI video analysis — break any video down shot by shot and recover the exact generation prompts behind it. | **Free credits on signup** | 2026-12-31 |
 | 🖼️ | [ThumblifyAI](https://thumblifyai.com) | Create scroll-stopping YouTube thumbnails in your own style or face with AI. | **30% OFF** with discount code **WELCOME30** | 2025-12-01 |
 | 👀 | [ChampSignal](https://champsignal.com) | ChampSignal tracks your competitors' websites, social mentions, ads, backlinks, and keywords, and sends you email alerts only when it matters. | **25% OFF** with code **BF2025** | 2025-12-01 |
 | 🤖 | [ShowUpInAI](https://showupinai.com) | Get Cited in ChatGPT and more! We push every new page to Bing, helping AI assistants cite your site. | **25% OFF** with code **BLACKFRIDAY25** | 2025-12-01 |


### PR DESCRIPTION
Adding **VideoLens** — a professional AI video analysis tool that breaks any video down shot by shot and recovers the exact generation prompts behind it.

- Site: https://videolens.cc
- Category: AI Tools › Other
- Deal: Free credits on signup

Thanks for maintaining this list! ✨