### PR TITLE
Add Ripdex - TCG Card Scanner (iOS Apps > Hobby & Lifestyle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Free & open-source.
 | 💸 | [ToMoment](https://apps.apple.com/ar/app/event-countdown-tomoment/id6751402161?l=en-GB) | Track every important moment with unlimited countdowns and live updates that keep you perfectly on time. | **75% OFF** Lifetime (auto-applied) | 2025-12-04 |
 | 🎴 | [Eyevo - TCG Scanner for Pokemon](https://eyevotcg.com/) | Scan, price, and manage your Pokemon TCG collection | **70% OFF** Lifetime PRO (auto-applied in app) | 2025-12-03 |
 | 🔮 | [esotericAI](https://esotericai.xyz?ref=rarebigdeal) | AI-powered tarot readings and cosmic blueprint astrology insights for self-discovery | Get **free credits on signup** to explore tarot readings and cosmic insights and **50% OFF on subscriptions** with code rarebigdeal auto applied on signup | 2026-12-31 |
+| 🃏 | [Ripdex - TCG Card Scanner](https://getripdex.com) | Scan any Pokemon card for instant ID, live TCGplayer prices, 90-day trends and a collection tracker. 47,000+ cards. | **FREE** to download on iOS, premium unlocks unlimited scanning | 2026-12-31 |
 
 
 ### Other


### PR DESCRIPTION
Adds Ripdex, a free Pokemon card scanner and price tracker, at the bottom of iOS Apps > Hobby & Lifestyle. One line in the README, no reformatting. Free to download on iOS, premium unlocks unlimited scanning.