### PR TITLE
Add Chemistry AI free credits deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Free & open-source.
 
 | | Name | Description | Deal | Expires on date |
 | - | - | - | - | - |
+| 🧪 | [Chemistry AI](https://chemistryai.chat/) | Interactive AI chemistry tutor with step-by-step explanations for students and self-learners. | Free credits with no sign-up required | |
 | 🖼️ | [ThumblifyAI](https://thumblifyai.com) | Create scroll-stopping YouTube thumbnails in your own style or face with AI. | **30% OFF** with discount code **WELCOME30** | 2025-12-01 |
 | 👀 | [ChampSignal](https://champsignal.com) | ChampSignal tracks your competitors' websites, social mentions, ads, backlinks, and keywords, and sends you email alerts only when it matters. | **25% OFF** with code **BF2025** | 2025-12-01 |
 | 🤖 | [ShowUpInAI](https://showupinai.com) | Get Cited in ChatGPT and more! We push every new page to Bing, helping AI assistants cite your site. | **25% OFF** with code **BLACKFRIDAY25** | 2025-12-01 |


### PR DESCRIPTION
Add Chemistry AI to the AI Tools / Other table with its browser-based tutoring description and free no-signup offer.