### PR TITLE
Add RAADS-R Test to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Free & open-source.
 | 🧠 | [Quizify](https://quizify.io/?utm_source=rarebigdeal) | AI-powered platform for creating interactive quizzes, forms, and surveys without coding. | **25% OFF** Annual plan with code **RAREBIGDEAL25** | 2026-12-31 |
 | 🔮 | [esotericAI](https://esotericai.xyz?ref=rarebigdeal) | AI-powered tarot readings and cosmic blueprint astrology insights for self-discovery | Get **free credits on signup** to explore tarot readings and cosmic insights and **50% OFF on subscriptions** with code rarebigdeal auto applied on signup | 2026-12-31 |
 | | [Foca Upscaler](https://focaupscaler.com) | AI image upscaler and enhancer for improving blurry, low-resolution, and compressed images while preserving realistic textures and natural detail. | Get **15 free credits on signup** and **20% OFF** first payment with code **RAREBIGDEAL20** | 2026-05-31 |
+| 🧩 | [RAADS-R Test](https://raads-rtest.online/) | Free browser-based informational self-assessment for adults exploring possible autistic traits, with private total and domain results and clear non-diagnostic guidance. | **Free to use** — no coupon code or account required | |
 
 
 ### Lifestyle


### PR DESCRIPTION
Adds RAADS-R Test beneath Foca Upscaler in the AI Tools section.

- Links to the exact public homepage: https://raads-rtest.online/
- Describes the free browser-based informational self-assessment truthfully
- Lists the current deal as free to use with no coupon code or account required
- Leaves the expiry blank because the free access is ongoing

The comparison contains exactly one README addition and no deletions.