### PR TITLE
Add AI Interior Design to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Free & open-source.
 | 🧠 | [Quizify](https://quizify.io/?utm_source=rarebigdeal) | AI-powered platform for creating interactive quizzes, forms, and surveys without coding. | **25% OFF** Annual plan with code **RAREBIGDEAL25** | 2026-12-31 |
 | 🔮 | [esotericAI](https://esotericai.xyz?ref=rarebigdeal) | AI-powered tarot readings and cosmic blueprint astrology insights for self-discovery | Get **free credits on signup** to explore tarot readings and cosmic insights and **50% OFF on subscriptions** with code rarebigdeal auto applied on signup | 2026-12-31 |
 | | [Foca Upscaler](https://focaupscaler.com) | AI image upscaler and enhancer for improving blurry, low-resolution, and compressed images while preserving realistic textures and natural detail. | Get **15 free credits on signup** and **20% OFF** first payment with code **RAREBIGDEAL20** | 2026-05-31 |
+| 🏠 | [AI Interior Design](https://ai-interior-design.online/) | AI-powered interior design tool that turns room photos into realistic redesign concepts for residential and commercial spaces. | **Free to use** | |
 
 
 ### Lifestyle


### PR DESCRIPTION
Adds one truthful AI Tools row for AI Interior Design.

- Website: https://ai-interior-design.online/
- Product: browser-based AI room redesign tool
- Deal: free to use
- Expiry: left blank because the free access is not presented as a time-limited promotion

The change contains exactly one README addition and no deletions.